### PR TITLE
Double banner css

### DIFF
--- a/assets/section-double-image-banner.css
+++ b/assets/section-double-image-banner.css
@@ -78,7 +78,7 @@
   width: 50%;
 }
 
-.banner__media-half + .banner__media-half {
+.banner__media-half + .banner__content + .banner__media-half {
   right: 0;
   left: auto;
 }
@@ -299,7 +299,6 @@
     padding: 4rem;
     width: auto;
     max-width: 71rem;
-    min-width: 45rem;
     margin: 0 2rem;
   }
 

--- a/assets/section-double-image-banner.css
+++ b/assets/section-double-image-banner.css
@@ -78,7 +78,7 @@
   width: 50%;
 }
 
-.banner__media-half + .banner__content + .banner__media-half {
+.banner__media-half ~ .banner__media-half {
   right: 0;
   left: auto;
 }


### PR DESCRIPTION
Hey Aja,

This should fix the double banner. I didn't have to move any HTML, but did have to set it up so that this rule is selecting the right child:

```css
.banner__media-half ~ .banner__media-half {
  right: 0;
  left: auto;
}
``` 

The `+` css selector is a direct sibling so it has to be right next to the other element, but a `~` selector is a [general sibling selector](https://developer.mozilla.org/en-US/docs/Web/CSS/General_sibling_combinator)